### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pramodhm/92d8d786-e9d3-4933-ab48-21e36c949d81/fd4c20b7-4393-4c84-a29b-74c4602db220/_apis/work/boardbadge/9169c807-9406-4773-b661-1f2c75315974)](https://dev.azure.com/pramodhm/92d8d786-e9d3-4933-ab48-21e36c949d81/_boards/board/t/fd4c20b7-4393-4c84-a29b-74c4602db220/Microsoft.RequirementCategory)
 # This is sample math code
 
 ## Given a number n, finds the sum of numbers from 1 to n


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#575](https://dev.azure.com/pramodhm/92d8d786-e9d3-4933-ab48-21e36c949d81/_workitems/edit/575). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.